### PR TITLE
Fix possible destructuring error

### DIFF
--- a/src/sam/02-after/00-get-app-apex/cloudfront-list.js
+++ b/src/sam/02-after/00-get-app-apex/cloudfront-list.js
@@ -7,11 +7,12 @@ module.exports = function listCloudfrontDistributions(callback) {
   let cf = new aws.CloudFront
   let distros = []
   function list(params={}) {
-    cf.listDistributions(params, function done(err, {DistributionList, NextMarker}) {
+    cf.listDistributions(params, function done(err, res) {
       if (err) {
         callback(err)
       }
       else {
+        let {DistributionList, NextMarker} = res
         distros = distros.concat(DistributionList.Items)
         if (NextMarker) {
           list({Marker: NextMarker})


### PR DESCRIPTION
If Cloudfront listDistributions returns an error and the response is `null` (or undefined), the method currently throws this error:

```TypeError: Cannot destructure property `DistributionList` of 'undefined' or 'null'.```

The changeset moves the destructuring inside the method where we know the value is defined.