### PR TITLE
add ability for specific local function paths to be deployed

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,7 +34,7 @@ async function cmd(opts=[]) {
   // read args into {prune, verbose, production, tags, name, isFullDeploy}
   let args = options(opts)
 
-  if (args.isDirty) {
+  if (args.isDirty || args.srcDirs.length) {
     let result = await deploy.dirty(args)
     pauser.unpause()
     return result

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npm run lint && npm run coverage",
     "test:slow": "tape test/slow/*-test.js | tap-spec",
-    "test:unit": "tape test/*-test.js test/static/*-test.js | tap-spec",
+    "test:unit": "tape test/unit/*-test.js test/unit/**/*-test.js test/unit/**/**/*-test.js | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"

--- a/src/dirty/deploy-nested-stack.js
+++ b/src/dirty/deploy-nested-stack.js
@@ -6,7 +6,7 @@ let waterfall = require('run-waterfall')
 let deploy = require('./deploy-one')
 let pretty = require('./pretty')
 
-module.exports = function deploySAM({stackname, arc, ts, update}, callback) {
+module.exports = function deploySAM({stackname, arc, ts, update, specificLambdasToDeploy}, callback) {
   /**
    * To see a World in a Grain of Sand,
    * And a Heaven in a Wild Flower,
@@ -63,7 +63,7 @@ module.exports = function deploySAM({stackname, arc, ts, update}, callback) {
     },
 
     function readLocal(functions, callback) {
-      let {localPaths} = utils.inventory(arc)
+      let localPaths = specificLambdasToDeploy.length ? specificLambdasToDeploy : utils.inventory(arc).localPaths
       parallel(localPaths.map(pathToCode=> {
         return function one(callback) {
           let folder = pathToCode.split('/').reverse().shift()

--- a/src/dirty/deploy-sam-stack.js
+++ b/src/dirty/deploy-sam-stack.js
@@ -6,7 +6,7 @@ let waterfall = require('run-waterfall')
 let deploy = require('./deploy-one')
 let pretty = require('./pretty')
 
-module.exports = function deploySAM({stackname, arc, ts, update}, callback) {
+module.exports = function deploySAM({stackname, arc, specificLambdasToDeploy, ts, update}, callback) {
   waterfall([
 
     function readResources(callback) {
@@ -25,7 +25,7 @@ module.exports = function deploySAM({stackname, arc, ts, update}, callback) {
     },
 
     function readLocal(functions, callback) {
-      let {localPaths} = utils.inventory(arc)
+      let localPaths = specificLambdasToDeploy.length ? specificLambdasToDeploy : utils.inventory(arc).localPaths
       parallel(localPaths.map(pathToCode=> {
         return function one(callback) {
           let folder = pathToCode.split('/').reverse().shift()

--- a/src/options.js
+++ b/src/options.js
@@ -1,3 +1,5 @@
+let fs = require('fs')
+
 let isDirty =   opt => opt === 'dirty' || opt === '--dirty' || opt === '-d'
 let isDryRun =  opt => opt === '--dry-run'
 let isProd =    opt => opt === 'production' || opt === '--production' || opt === '-p'
@@ -15,6 +17,7 @@ module.exports = function options(opts) {
     production: opts.some(isProd),
     tags: getTags(opts),
     name: getName(opts),
+    srcDirs: getSrcDirs(opts),
     isDirty: opts.some(isDirty),
     isDryRun: opts.some(isDryRun),
     isStatic: opts.some(isStatic),
@@ -48,4 +51,17 @@ function getName(list) {
   else {
     return operator.split('=')[1]
   }
+}
+
+function getSrcDirs(list) {
+  return list.reduce((acc, f) => {
+    if (!f.startsWith('src')) return acc
+    try {
+      let s = fs.statSync(f)
+      if (s.isDirectory()) {
+        acc.push(f)
+      }
+      return acc
+    } catch (e) { return acc }
+  }, [])
 }

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -1,5 +1,5 @@
 let test = require('tape')
-let index = require('../')
+let index = require('../../')
 
 test('module should have three functions', t => {
   t.plan(3)

--- a/test/unit/options-test.js
+++ b/test/unit/options-test.js
@@ -1,0 +1,27 @@
+let test = require('tape')
+let options = require('../../src/options')
+
+test('should return three dirty option varieties', t => {
+  t.plan(3)
+  t.ok(options(['arc', 'deploy', 'dirty', 'staging']).isDirty, '"dirty" param sets isDirty')
+  t.ok(options(['arc', 'deploy', '--dirty', 'staging']).isDirty, '"--dirty" param sets isDirty')
+  t.ok(options(['arc', 'deploy', '-d', 'staging']).isDirty, '"-d" param sets isDirty')
+})
+
+test('should return dryrun option', t => {
+  t.plan(1)
+  t.ok(options(['arc', 'deploy', '--dry-run', 'staging']).isDryRun, '"--dry-run" param sets isDryRun')
+})
+
+test('should return three production option varieties', t => {
+  t.plan(3)
+  t.ok(options(['arc', 'deploy', 'production']).production, '"production" param sets production')
+  t.ok(options(['arc', 'deploy', '--production']).production, '"--production" param sets production')
+  t.ok(options(['arc', 'deploy', '-p']).production, '"-p" param sets production')
+})
+
+test('should return any directories under `src/` specified via `srcDirs`', t => {
+  t.plan(1)
+  let dirs = options(['arc', 'deploy', 'src']).srcDirs
+  t.ok(dirs.includes('src'),  'able to identify local "src" dir')
+})

--- a/test/unit/static/index-test.js
+++ b/test/unit/static/index-test.js
@@ -4,7 +4,7 @@ let proxyquire = require('proxyquire')
 let utils = require('@architect/utils')
 let aws = require('aws-sdk-mock')
 let publishFake = sinon.fake.yields()
-let index = proxyquire('../../src/static', {
+let index = proxyquire('../../../src/static', {
   './publish-to-s3': publishFake
 })
 let stackFake = sinon.fake.yields(null, {

--- a/test/unit/static/publish-to-s3-test.js
+++ b/test/unit/static/publish-to-s3-test.js
@@ -9,7 +9,7 @@ let utils = {
   fingerprint: sinon.stub().callsFake((params, callback) => callback(null, {}))
 }
 let globStub = sinon.stub().callsFake((path, options, callback) => callback(null, []))
-let publish = proxyquire('../../src/static/publish-to-s3', {
+let publish = proxyquire('../../../src/static/publish-to-s3', {
   '@architect/utils': utils,
   'glob': globStub
 })


### PR DESCRIPTION
This PR adds the option to deploy one or more function code paths using the existing dirty deploy mechanism. It does so by:

1. When parsing command line options, it looks at which parameters are legit file system directories that begin with `src`,
2. If any such path parameters are passed in, deploy routes the handling logic through the `dirty` module,
3. Compares the provided directories against arc's inventory `localPaths` to find matches, and
4. Feeds any such matches through to either SAM or nested deploy modules (depending on which method is used), which is used in place of using all of arc's inventory `localPaths` every time

The implementation ends up doing rough subdirectory matching under `src/`. So, `arc deploy src` is identical to `arc deploy dirty`. Further bonus points: `arc deploy src/http` dirty-deploys all http handlers, `arc deploy src/events` dirty-deploys all event handlers, etc.

Tangentially, I also did a bit of unit test moving around, to have any unit tests exist under `test/unit` and have the directory structure there reflect the same structure that `src/` has.

One thing I did notice this new functionality lacked was understanding _what_ is being deployed out. I was thinking it would be nice if in the dirty deploy flow, upon completion, logged out how many functions were deployed, rather than the current reporting which just says it "deployed app":

```
✓ Deploy Deployed dirtily
✓ Success! Deployed app in 2.306 seconds
```

Instead of the above, perhaps it would be nice if it said "Deployed 10 functions" instead of "Deployed app"? It would give some feedback to the user on if their more specific deploy targets was picked up correctly. Not sure, thinking out loud here.

This PR should address https://github.com/architect/architect/issues/625