### PR TITLE
tape glob and fix running unit tests locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "arc-deploy": "cli.js"
   },
   "scripts": {
-    "test": "npm run lint && npm run coverage",
-    "test:slow": "tape test/slow/*-test.js | tap-spec",
-    "test:unit": "tape 'test/unit/**/*-test.js' 'test/integration/**/*-test.js' | tap-spec",
+    "test": "npm run lint && npm run test:integration && npm run coverage",
+    "test:slow": "tape 'test/slow/**/*-test.js' | tap-spec",
+    "test:unit": "tape 'test/unit/**/*-test.js' | tap-spec",
+    "test:integration": "tape 'test/integration/**/*-test.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"

--- a/test/unit/static/publish/s3/delete-files/index-test.js
+++ b/test/unit/static/publish/s3/delete-files/index-test.js
@@ -192,6 +192,7 @@ test('Prune respects both prefix & fingerprint settings together in nested folde
 
 test('Teardown', t => {
   t.plan(1)
-  awsMock.restore()
+  awsMock.restore('S3', 'listObjectsV2')
+  awsMock.restore('S3', 'deleteObjects')
   t.pass('Done')
 })

--- a/test/unit/static/publish/s3/put-files/index-test.js
+++ b/test/unit/static/publish/s3/put-files/index-test.js
@@ -94,6 +94,7 @@ test('Skip publishing files that have not been updated', t => {
 
 test('Teardown', t => {
   t.plan(1)
-  awsMock.restore()
+  awsMock.restore('S3', 'headObject')
+  awsMock.restore('S3', 'putObject')
   t.pass('Done')
 })


### PR DESCRIPTION
- split out unit and integration test (so that coverage only counts unit tests)
- use better test dir globbing with tape
- restore only mocked aws sdk methods to fix unit tests