### PR TITLE
split out running unit vs integration tests in npm run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "arc-deploy": "cli.js"
   },
   "scripts": {
-    "test": "npm run lint && npm run coverage",
+    "test": "npm run lint && npm run test:integration && npm run coverage",
     "test:slow": "tape test/slow/*-test.js | tap-spec",
-    "test:unit": "tape 'test/unit/**/*-test.js' 'test/integration/**/*-test.js' | tap-spec",
+    "test:unit": "tape 'test/unit/**/*-test.js' | tap-spec",
+    "test:integration": "tape 'test/integration/**/*-test.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text-summary npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"


### PR DESCRIPTION
...and only run coverage on unit tests
