### PR TITLE
when dirty deploying, deploy function code and config in series rather than parallel

### DIFF
--- a/src/dirty/deploy-one.js
+++ b/src/dirty/deploy-one.js
@@ -2,7 +2,6 @@ let series = require('run-series')
 let parse = require('@architect/parser')
 let fs = require('fs')
 let path = require('path')
-let parallel = require('run-parallel')
 let sploot = require('run-waterfall')
 let zip = require('./zip')
 let aws = require('aws-sdk')
@@ -16,20 +15,20 @@ let aws = require('aws-sdk')
  * @param {String} params.pathToCode - path on filesystem to function code
  */
 module.exports = function dirtyDeployOne ({ FunctionName, pathToCode }, callback) {
-  parallel({
-    code (callback) {
+  series([
+    function code (callback) {
       updateCode({
         FunctionName,
         pathToCode,
       }, callback)
     },
-    config (callback) {
+    function config (callback) {
       updateConfig({
         FunctionName,
         pathToCode,
       }, callback)
     }
-  },
+  ],
   function done (err) {
     if (err) callback(err)
     else callback()


### PR DESCRIPTION
… instead of parallel. I have noticed that this can lead to errors returned from CloudFormation like:

"The function could not be updated due to a concurrent update operation"

Which makes sense, if CloudFormation doesn't like both happening at the same time.

Applying this patch locally eliminated the issue for me.

It does not seem to have an impact on run time FWIW - always takes about 3 seconds for me regardless on if the tasks run in parallel or series.