### PR TITLE
Added `--no-hydrate` CLI flag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [2.3.4] 2021-01-23
+
+### Added
+
+- Added `--no-hydrate` CLI flag to skip hydration before a deploy
+
+---
+
 ## [2.3.3] 2021-01-07
 
 ### Fixed

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -15,11 +15,13 @@ let update = updater('Deploy')
  *
  * options
  * -p|--production|production ... deploys to AppNameProduction
- * -d|--direct|direct ........... direct deploy function code/config
- * -s|--static|static ........... direct deploys /public to s3 bucket
+ * -d|--direct|direct ........... direct deploy a specific function code/config
+ * -s|--static|static ........... direct deploys /public to static s3 bucket
  * -v|--verbose|verbose ......... prints all output to console
  * -t|--tags|tags ............... add tags
  * -n|--name|name ............... customize stack name
+ * --prune ...................... remove files that exist in static s3 bucket but do not exist in local /public folder
+ * --dry-run .................... assemble CloudFormation sam.json but do not deploy remotely (useful for testing macros)
  */
 async function cmd () {
   let inventory = await _inventory({ env: true })

--- a/src/cli/options.js
+++ b/src/cli/options.js
@@ -7,6 +7,7 @@ let isProd =    opt => opt === 'production' || opt === '--production' || opt ===
 let isPrune =   opt => opt === 'prune' || opt === '--prune'
 let isStatic =  opt => opt === 'static' || opt === '--static' || opt === '-s'
 let isVerbose = opt => opt === 'verbose' || opt === '--verbose' || opt === '-v'
+let isNoHydrate = opt => opt === '--no-hydrate'
 
 let tags =      arg => arg === '--tags' || arg === '-t' || arg === 'tags'
 let apiType =   arg => arg.startsWith('--apigateway')
@@ -24,7 +25,8 @@ module.exports = function options (opts) {
     isDirect: opts.some(isDirect),
     isDryRun: opts.some(isDryRun),
     isStatic: opts.some(isStatic),
-    isFullDeploy: opts.some(isStatic) ? false : true
+    isFullDeploy: opts.some(isStatic) ? false : true,
+    shouldHydrate: opts.some(isNoHydrate) ? false : true
   }
 }
 

--- a/src/sam/index.js
+++ b/src/sam/index.js
@@ -26,6 +26,7 @@ module.exports = function samDeploy (params, callback) {
     apiType,
     inventory,
     isDryRun = false,
+    shouldHydrate = true,
     name,
     production,
     prune,
@@ -135,7 +136,8 @@ module.exports = function samDeploy (params, callback) {
      * Hydrate dependencies
      */
     function hydrateTheThings (callback) {
-      hydrate.install({ autoinstall: true }, callback)
+      if (shouldHydrate) hydrate.install({ autoinstall: true }, callback)
+      else callback()
     },
 
     /**

--- a/test/unit/options-test.js
+++ b/test/unit/options-test.js
@@ -27,6 +27,12 @@ test('should return isStatic option', t => {
   t.ok(options([ 'arc', 'deploy', '-s' ]).isStatic, '"-s" param sets isStatic')
 })
 
+test('should return shouldHydrate option', t => {
+  t.plan(2)
+  t.notOk(options([ 'arc', 'deploy', '--no-hydrate' ]).shouldHydrate, '"--no-hydrate" param sets shouldHydrate to false')
+  t.ok(options([ 'arc', 'deploy' ]).shouldHydrate, 'lack of "--no-hydrate" param sets shouldHydrate to true')
+})
+
 test('should return apiType', t => {
   t.plan(1)
   t.equal(options([ 'arc', 'deploy', '--apigateway', 'http' ]).apiType, 'http', '"--apigatewa" param sets isStatic')


### PR DESCRIPTION
... allows for skipping hydration before a deploy.

This fixes https://github.com/architect/architect/issues/1054.