### PR TITLE
Fix issue with plugins implementation

### DIFF
--- a/src/sam/index.js
+++ b/src/sam/index.js
@@ -214,7 +214,7 @@ module.exports = function samDeploy (params, callback) {
     function runPlugins (callback) {
       plugins(
         inventory,
-        cloudformation,
+        sam,
         stage,
         function done (err, _sam) {
           if (err) callback(err)


### PR DESCRIPTION
Currently, it looks like any changes made by macros get lost when plugins run.

Changing the input to plugins so it takes the modified `sam` variable output from macros fixes architect/architect#1127 for me - but I'm confused as to how this apparent bug hasn't been more obvious, or rather, caused lots of issues before?

Equally concerned I've totally missed what's going on between the `cloudFormation` and `sam` variables and this "fix" could be way off...?