### PR TITLE
fix disappearing cloudformation json bits

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .nyc_output/
 coverage/
 node_modules/
+test/mocks

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 node_modules/
 package-lock.json
 scratch/
+test/mocks/app-with-extensions/sam.json

--- a/changelog.md
+++ b/changelog.md
@@ -2,11 +2,19 @@
 
 ---
 
+## [2.5.2] 2021-04-22
+
+### Fixed
+
+- Fixed bug where macros that were returning copies of CloudFormation JSON would lose CloudFormation state; fixes [#1127](https://github.com/architect/architect/issues/1127)
+
+---
+
 ## [2.5.1] 2021-03-24
 
 ### Fixed
 
-- Fixed deployments for legacy REST APIs that do not have a root handler defined; fixes #1089
+- Fixed deployments for legacy REST APIs that do not have a root handler defined; fixes [#1089](https://github.com/architect/architect/issues/1089)
 - Error gracefully when new verbose route format is used with legacy REST APIs
 
 ---

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run lint && npm run test:integration && npm run coverage",
     "test:unit": "cross-env tape 'test/unit/**/*-test.js' | tap-spec",
     "test:slow": "cross-env tape 'test/slow/**/*-test.js' | tap-spec",
-    "test:integration": "cross-env tape 'test/integration/**/*-test.js' | tap-spec",
+    "test:integration": "cross-env AWS_ACCESS_KEY_ID=\"blah\" AWS_SECRET_ACCESS_KEY=\"blah\" tape 'test/integration/**/*-test.js' | tap-spec",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test:unit",
     "lint": "eslint . --fix",
     "rc": "npm version prerelease --preid RC"

--- a/src/sam/00-before/index.js
+++ b/src/sam/00-before/index.js
@@ -12,5 +12,7 @@ module.exports = function pkg (params, callback) {
   series([
     writeSAM.bind({}, { sam, update }),
     writeCFN.bind({}, { sam, bucket, pretty, update, isDryRun })
-  ], callback)
+  ], (err) => {
+    callback(err)
+  })
 }

--- a/test/integration/macros-n-plugins-test.js
+++ b/test/integration/macros-n-plugins-test.js
@@ -1,0 +1,36 @@
+let test = require('tape')
+let { join } = require('path')
+let origDir = process.cwd()
+let sam = require('../../src/sam')
+let inventory = require('@architect/inventory')
+let inv
+
+test('end-to-end sam setup', t => {
+  t.plan(3)
+  process.chdir(join(__dirname, '..', 'mocks', 'app-with-extensions'))
+  t.pass('chdir to mock app')
+  inventory({}, (err, result) => {
+    t.notOk(err, 'no error retrieving inventory from mock app')
+    t.ok(result, 'got some manner of inventory')
+    inv = result
+  })
+})
+
+test('multiple macro and plugin cfn additions honoured', t => {
+  t.plan(5)
+  sam({ isDryRun: true, shouldHydrate: false, region: 'us-west-2', inventory: inv, verbose: true }, (err) => {
+    t.notOk(err, 'no error from sam method')
+    // eslint-disable-next-line global-require
+    let json = require(join(process.cwd(), 'sam.json'))
+    t.ok(json.macroOne, 'first macro cfn addition present')
+    t.ok(json.macroTwo, 'second macro cfn addition present')
+    t.ok(json.pluginOne, 'first plugin cfn addition present')
+    t.ok(json.pluginTwo, 'second plugin cfn addition present')
+  })
+})
+
+test('end-to-end sam teardown', t => {
+  t.plan(1)
+  process.chdir(origDir)
+  t.pass('chdir to original')
+})

--- a/test/mocks/app-with-extensions/app.arc
+++ b/test/mocks/app-with-extensions/app.arc
@@ -1,0 +1,17 @@
+@app
+app-with-extensions
+
+@aws
+apigateway http
+region us-west-2
+
+@http
+get /
+
+@macros
+one
+two
+
+@plugins
+one
+two

--- a/test/mocks/app-with-extensions/src/http/get-index/config.arc
+++ b/test/mocks/app-with-extensions/src/http/get-index/config.arc
@@ -1,0 +1,5 @@
+@aws
+runtime nodejs12.x
+# memory 1152
+# timeout 30
+# concurrency 1

--- a/test/mocks/app-with-extensions/src/http/get-index/index.js
+++ b/test/mocks/app-with-extensions/src/http/get-index/index.js
@@ -1,0 +1,10 @@
+exports.handler = async function http (req) {
+  return {
+    statusCode: 200,
+    headers: {
+      'cache-control': 'no-cache, no-store, must-revalidate, max-age=0, s-maxage=0',
+      'content-type': 'text/html; charset=utf8'
+    },
+    body: `yo`
+  }
+}

--- a/test/mocks/app-with-extensions/src/macros/one.js
+++ b/test/mocks/app-with-extensions/src/macros/one.js
@@ -1,0 +1,4 @@
+module.exports = function (arc, cfn) {
+  cfn.macroOne = true
+  return cfn
+}

--- a/test/mocks/app-with-extensions/src/macros/two.js
+++ b/test/mocks/app-with-extensions/src/macros/two.js
@@ -1,0 +1,4 @@
+module.exports = (arc, cfn) => ({
+  ...cfn,
+  macroTwo: true
+})

--- a/test/mocks/app-with-extensions/src/plugins/one.js
+++ b/test/mocks/app-with-extensions/src/plugins/one.js
@@ -1,0 +1,6 @@
+module.exports = {
+  package: function ({ cloudformation }) {
+    cloudformation.pluginOne = true
+    return cloudformation
+  }
+}

--- a/test/mocks/app-with-extensions/src/plugins/two.js
+++ b/test/mocks/app-with-extensions/src/plugins/two.js
@@ -1,0 +1,6 @@
+module.exports = {
+  package: function ({ cloudformation }) {
+    cloudformation.pluginTwo = true
+    return cloudformation
+  }
+}

--- a/test/unit/sam/index-test.js
+++ b/test/unit/sam/index-test.js
@@ -1,0 +1,82 @@
+let test = require('tape')
+let proxyquire = require('proxyquire')
+let baseCfn = { Resources: {} }
+let finalCfn
+let _deploy = {}
+let sam = proxyquire('../../../src/sam', {
+  '../utils/handler-check': (dirs, update, cb) => cb(),
+  './bucket': (params, cb) => cb(null, 'bucket'),
+  '@architect/hydrate': () => ({ install: (params, cb) => cb() }),
+  '@architect/utils': {
+    toLogicalId: (s) => s,
+    updater: () => ({ done: () => {}, status: () => {} }),
+    fingerprint: (params, cb) => cb()
+  },
+  '@architect/package': () => baseCfn,
+  './compat': (params, cb) => cb(null, _deploy),
+  '../utils/size-report': (params, cb) => cb(),
+  './00-before': (params, cb) => {
+    // save the final CFN JSON for inspection
+    finalCfn = params.sam
+    cb()
+  },
+  './01-deploy': (params, cb) => cb(),
+  './02-after': (params, cb) => cb()
+})
+
+let invGetter = {
+  get: {
+    static: () => undefined
+  }
+}
+let baseInv = {
+  app: 'testapp',
+  aws: {
+  },
+  _project: {
+    arc: { }
+  },
+}
+
+function resetCfnAndGenerateInventory (cfn, inv) {
+  // reset the base cloudformation we will use as a fake returned from `package`
+  baseCfn = cfn || { Resources: {} }
+  // reset the var that captures the final compiled cfn right before writing it out
+  finalCfn = undefined
+  // return a compiled inventory if provided
+  return Object.assign({}, invGetter, { inv: inv ? inv : baseInv })
+}
+
+test('sam smoketest', t => {
+  t.plan(1)
+  let inventory = resetCfnAndGenerateInventory()
+  sam({ inventory, shouldHydrate: false }, (err) => {
+    t.notOk(err, 'no error during smoketest')
+  })
+})
+
+test('sam internal arc-env macro mutations should be honoured', t => {
+  t.plan(2)
+  let inv = JSON.parse(JSON.stringify(baseInv))
+  inv._project.env = {
+    staging: {
+      myEnvVar: 'sprettydope'
+    }
+  }
+  let inventory = resetCfnAndGenerateInventory({
+    Resources: {
+      'SomeLambda': {
+        Type: 'AWS::Serverless::Function',
+        Properties: {
+          Environment: {
+            Variables: {}
+          }
+        }
+      }
+    }
+  }, inv)
+  sam({ inventory, shouldHydrate: false }, (err) => {
+    t.notOk(err, 'no error')
+    t.equals(finalCfn.Resources.SomeLambda.Properties.Environment.Variables.myEnvVar, 'sprettydope', 'env var from inventory set on lambda')
+  })
+})


### PR DESCRIPTION
fix bug with wrong base cloudformation json being used between macro and plugin-modified cloudformation mutations. this fixes architect/architect#1127

- added unit test for sam module
- added integration test for combo of macro and plugin using app.
- eliminated side effect variables, used waterfall to pass modified objects around instead of series.
- added mock app for integration test

wouldn't mind a review @ryanblock / @brianleroux as I changed the order of some of the inventory mutations being done to bunch those together in order for the macro and plugin CFN mutation sections to be grouped together and feeding cloudformation JSON into each other.