### PR TITLE
fix userland macro and plugin processing order

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ---
 
+## [2.5.4] 2021-04-26
+
+### Fixed
+
+- Fixed bug where plugin-generated Lambdas would not have proper built-in production environment variables assigned when running a production deploy; fixes [#1134](https://github.com/architect/architect/issues/1134)
+
+---
+
 ## [2.5.3] 2021-04-23
 
 ### Fixed

--- a/src/sam/index.js
+++ b/src/sam/index.js
@@ -191,17 +191,20 @@ module.exports = function samDeploy (params, callback) {
     },
 
     /**
+     * Userland Plugins
+     * WARNING: order matters here. Plugins must run before macros because
+     * built-in macros also run things that may impact userland resources (i.e.
+     * environment variables set on plugin or macro-generated Lambdas)
+     */
+    function runPlugins (macroModifiedCfn, callback) {
+      plugins(inventory, macroModifiedCfn, stage, callback)
+    },
+
+    /**
      * Macros (both built-in + user)
      */
     function runMacros (cloudformation, callback) {
       macros(inventory, cloudformation, stage, callback)
-    },
-
-    /**
-     * Userland Plugins
-     */
-    function runPlugins (macroModifiedCfn, callback) {
-      plugins(inventory, macroModifiedCfn, stage, callback)
     },
 
     /**

--- a/src/sam/macros/index.js
+++ b/src/sam/macros/index.js
@@ -52,6 +52,7 @@ module.exports = function macros (inventory, cloudformation, stage, callback) {
 async function exec (inventory, cloudformation, stage) {
   let arc = inventory.inv._project.arc
   let transforms = arc.macros || []
+  // WARNING! Order matters below. the `arc-env` internal macro MUST run AFTER any userland macros and plugins
   // Always run the following internal macros:
   transforms.push(
     'legacy-api', // Use legacy REST APIs instead of HTTP APIs for @http; must run before other macros


### PR DESCRIPTION
ensure userland bits happen first before built-in macros execute.
added warning comments explaining order of this processing matters for any future code pioneers

this fixes architect/architect#1134