### PR TITLE
Fix CloudFormation bucket name validation and SSM parameter name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ---
 
+## [4.1.5]
+
+### Fixed
+
+- Fixed issue where Deploy create CloudFormation template bucket on each deploy; fixes #357
+
 ## [4.1.4] 2022-07-22
 
 ### Changed

--- a/src/sam/bucket/create-bucket.js
+++ b/src/sam/bucket/create-bucket.js
@@ -5,11 +5,11 @@ let series = require('run-series')
 module.exports = function createDeployBucket ({ appname, region, update }, callback) {
 
   // Quick validation for S3 bucket naming requirements
-  appname = appname.split('_').join('-')
-  appname = appname.split('..').join('.')
-  appname = appname.split('-.').join('-')
-  appname = appname.split('.-').join('-')
-  appname = appname.substr(0, 38) // No more than 63 chars
+  bucket_appname = appname.split('_').join('-')
+  bucket_appname = bucket_appname.split('..').join('.')
+  bucket_appname = bucket_appname.split('-.').join('-')
+  bucket_appname = bucket_appname.split('.-').join('-')
+  bucket_appname = bucket_appname.substr(0, 38) // No more than 63 chars
 
   // Create unique bucket name
   let seed = Buffer.from(`${appname}-${Date.now()}`)
@@ -17,7 +17,7 @@ module.exports = function createDeployBucket ({ appname, region, update }, callb
   createHash.update(seed)
   let hash = createHash.digest('hex').substr(0, 5)
   // Bucket names must be lower case
-  let bucket = `${appname}-cfn-deployments-${hash}`.toLowerCase()
+  let bucket = `${bucket_appname}-cfn-deployments-${hash}`.toLowerCase()
 
   series([
     function createBucket (callback) {


### PR DESCRIPTION
Hi, I made a PR that should fix SSM parameter name in projects with `_` in their name.

Related: https://github.com/architect/architect/issues/1363
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [x] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
