### PR TITLE
Add --stackname flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,11 +25,13 @@ You need to have the `sam` command-line utility available on your `$PATH`. Check
 Deploys function code directly to one or more staging (or production) environment Lambdas _by ommitting CloudFormation and directly updating code payloads_. This is very useful for live debugging; changes made with direct deploys should be considered temporary.
 
 
-### `deploy.sam({ verbose, production }, callback)`
+### `deploy.sam({ verbose, production, stackname }, callback)`
 
 Deploys all infrastructure associated to your @architect app.
 
 Set `verbose` to truthy to enable chatty mode. By default will only push to the staging environment unless `production` is truthy.
+
+Set `stackname` to set the name of the CloudFormation stack. Optional, defaults to the `${projectName}${stage}`.
 
 
 ### `deploy.static({ bucket, credentials, fingerprint, prefix, prune, region, verbose, production }, callback)`

--- a/src/cli/flags.js
+++ b/src/cli/flags.js
@@ -39,6 +39,7 @@ module.exports = function getFlags () {
     isStatic:       args.static,
     isFullDeploy:   args.static ? false : true,
     shouldHydrate:  args.hydrate,
+    stackname:      args.stackname,
   }
 }
 

--- a/src/sam/index.js
+++ b/src/sam/index.js
@@ -37,6 +37,7 @@ module.exports = function samDeploy (params, callback) {
     tags,
     update,
     verbose,
+    stackname,
   } = params
   let { inv, get } = inventory
   if (!update) update = updater('Deploy')
@@ -48,7 +49,7 @@ module.exports = function samDeploy (params, callback) {
   let appname = inv.app
   let bucket = inv.aws.bucket
   let prefs = inv._project.preferences
-  let stackname = `${toLogicalID(appname)}${production ? 'Production' : 'Staging'}`
+  stackname = stackname || `${toLogicalID(appname)}${production ? 'Production' : 'Staging'}`
   let dryRun = isDryRun || eject || false // General dry run flag for plugins
   let deployTargetPlugins = inventory.inv.plugins?._methods?.deploy?.target
   let plural = deployTargetPlugins?.length > 1 ? 's' : ''

--- a/test/unit/flags-test.js
+++ b/test/unit/flags-test.js
@@ -122,6 +122,16 @@ test('Tags', t => {
   t.deepEqual(flags().tags, [ tagA, tagB ], '"-t" flags returns multiple tags')
 })
 
+test('Stackname', t => {
+  t.plan(2)
+
+  args('')
+  t.notOk(flags().stackname, 'Specifying a source dir without the direct flag does nothing')
+
+  args(`--stackname MyStack`)
+  t.deepEqual(flags().stackname, 'MyStack', 'Specifying a stack name with the --stackname flag returns the stack name')
+})
+
 test('Teardown', t => {
   t.plan(1)
   process.argv = argv


### PR DESCRIPTION
This change adds a `--stackname` switch to the command line to override the default one constructed from the project name + stage.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Expanded test coverage related to your changes:
  - [x] Added and/or updated unit tests (if appropriate)
  - [x] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [x] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
