### PR TITLE
Automatically destroy deployment artifacts more than 1 week old; fixes #1399

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 coverage/
 node_modules/
 test/mocks
+scratch/

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 ---
 
+## [4.3.0] 2023-01-26
+
+### Added
+
+- Deploy now automatically destroys deployment artifacts more than 1 week old; fixes #1399, thanks @alexbepple!
+- Added support for destroying more than 1,000 old static assets per deployment with `prune` enabled
+
+---
+
 ## [4.2.11] 2023-01-18
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@architect/deploy",
-  "version": "4.2.11",
+  "version": "4.3.0-RC.0",
   "description": "Deploys @architect projects",
   "main": "index.js",
   "bin": {

--- a/src/sam/02-after/03-clean-up-artifacts.js
+++ b/src/sam/02-after/03-clean-up-artifacts.js
@@ -43,6 +43,7 @@ module.exports = function cleanUpOldDeployArtifacts (params, callback) {
           Bucket,
           items,
           log: verbose,
+          region,
           s3,
           update,
         }, callback)

--- a/src/sam/02-after/03-clean-up-artifacts.js
+++ b/src/sam/02-after/03-clean-up-artifacts.js
@@ -1,0 +1,56 @@
+let getAllS3Files = require('../../utils/get-all-s3-files')
+let bulkDelete = require('../../utils/bulk-delete')
+let aws = require('aws-sdk')
+
+module.exports = function cleanUpOldDeployArtifacts (params, callback) {
+  let {
+    bucket: Bucket,
+    region,
+    update,
+    verbose,
+  } = params
+
+  let s3 = new aws.S3({ region })
+  let week = 1000 * 60 * 60 * 24 * 7
+
+  if (verbose) {
+    update.status('Checking for stale deployment artifacts')
+  }
+  let noneFound = () => {
+    if (verbose) {
+      update.status('No stale deployment artifacts found')
+    }
+  }
+
+  getAllS3Files({ Bucket, s3 }, function _listObjects (err, filesOnS3) {
+    if (err) callback(err)
+    else if (!filesOnS3.length) {
+      noneFound()
+      callback()
+    }
+    else {
+      let items = filesOnS3.filter(item => {
+        let { LastModified } = item
+        let ts = new Date(LastModified)
+        let age = Date.now() - ts
+        return age >= week
+      })
+      if (items.length) {
+        if (verbose) {
+          update.status(`Destroying ${items.length} stale deployment artifacts`)
+        }
+        bulkDelete({
+          Bucket,
+          items,
+          log: verbose,
+          s3,
+          update,
+        }, callback)
+      }
+      else {
+        noneFound()
+        callback()
+      }
+    }
+  })
+}

--- a/src/sam/02-after/index.js
+++ b/src/sam/02-after/index.js
@@ -2,12 +2,14 @@ let series = require('run-series')
 let appApex  = require('./00-get-app-apex')
 let maybeInvalidate = require('./01-maybe-invalidate')
 let deployWS = require('./02-deploy-ws')
+let cleanup = require('./03-clean-up-artifacts')
 
 module.exports = function after (params, callback) {
   series([
     appApex.bind({}, params),
     maybeInvalidate.bind({}, params),
     deployWS.bind({}, params),
+    cleanup.bind({}, params),
   ], err => {
     if (err) callback(err)
     else callback()

--- a/src/sam/index.js
+++ b/src/sam/index.js
@@ -246,8 +246,9 @@ module.exports = function samDeploy (params, callback) {
       }
       else {
         let params = {
-          inventory,
+          bucket,
           compat,
+          inventory,
           pretty,
           production,
           prune,

--- a/src/utils/bulk-delete.js
+++ b/src/utils/bulk-delete.js
@@ -1,0 +1,36 @@
+let chalk = require('chalk')
+
+module.exports = function bulkDelete (params, callback) {
+  let { Bucket, items, log, region, s3, update } = params
+
+  // Re-filter just for Keys jic; extra properties will blow up the request
+  let objects = items.map(({ Key }) => ({ Key }))
+
+  function deleteItems () {
+    let deleteParams = {
+      Bucket,
+      Delete: {
+        Objects: objects.splice(0, 1000),
+        Quiet: false
+      }
+    }
+    s3.deleteObjects(deleteParams, function (err, data) {
+      if (err) {
+        update.error('Deleting objects on S3 failed')
+        update.error(err)
+        callback()
+      }
+      else {
+        if (log) {
+          data.Deleted.forEach(function (deletedFile) {
+            let last = `https://${Bucket}.s3.${region}.amazonaws.com/${deletedFile.Key}`
+            update.raw(`${chalk.red('[ ✗ Deleted  ]')} ${chalk.cyan(last)}`)
+          })
+        }
+        if (objects.length) deleteItems()
+        else callback()
+      }
+    })
+  }
+  deleteItems()
+}

--- a/src/utils/get-all-s3-files.js
+++ b/src/utils/get-all-s3-files.js
@@ -1,0 +1,24 @@
+module.exports = function getAllS3Files (params, callback) {
+  let { Bucket, Prefix, s3 } = params
+  let files = []
+
+  function getObjects (ContinuationToken) {
+    let getParams = { Bucket }
+    if (ContinuationToken) getParams.ContinuationToken = ContinuationToken
+    if (Prefix) getParams.Prefix = Prefix
+
+    s3.listObjectsV2(getParams, function _listObjects (err, result) {
+      if (err) callback(err)
+      else {
+        let { Contents, NextContinuationToken } = result
+        if (Contents.length) {
+          files.push(...Contents)
+          if (NextContinuationToken) getObjects(NextContinuationToken)
+          else callback(null, files)
+        }
+        else callback(null, files)
+      }
+    })
+  }
+  getObjects()
+}


### PR DESCRIPTION
Destroy more than 1,000 old static assets with `prune` enabled

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
