### PR TITLE
Fix buggy naming of SSM parameters from services plugins

### DIFF
--- a/src/sam/plugins/services.js
+++ b/src/sam/plugins/services.js
@@ -10,7 +10,7 @@ module.exports = function servicesPlugins (params, callback) {
     let { arc } = inventory.inv._project
     async function runPlugins () {
       for (let plugin of serviceDiscoveryPlugins) {
-        let pluginName = getLambdaName(plugin.name)
+        let pluginName = getLambdaName(plugin._plugin)
         let result = await plugin({ arc, cloudformation, dryRun, inventory, stage })
         if (result && Object.keys(result).length) {
           Object.entries(result).forEach(([ key, Value ]) => {


### PR DESCRIPTION
You can add custom service discovery output in a plugin like this:

```mjs
// src/exampleplugin.js

export const deploy = {
  services() {
    return {
      foo: 'bar'
    }
  }
}
```

This should map to SSM parameter
`/${AWS::StackName}/exampleplugin/foo` and the service discovery output `{exampleplugin: {foo: 'bar'}}`.

However, it was mapping incorrectly to the SSM parameter `/${AWS::StackName}/services/foo` and the service discovery output `{services: {foo: 'bar'}}`.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
