### PR TITLE
Adds --no-fail-on-empty-changset flag to CloudFormation deploy call

### DIFF
--- a/src/sam/01-deploy/index.js
+++ b/src/sam/01-deploy/index.js
@@ -11,7 +11,8 @@ module.exports = function deploy (params, callback) {
     '--stack-name', stackname,
     '--s3-bucket', bucket,
     '--capabilities', 'CAPABILITY_IAM CAPABILITY_AUTO_EXPAND',
-    '--region', region
+    '--region', region,
+    '--no-fail-on-empty-changeset'
   ]
   if (tags.length > 0) {
     args.push('--tags')

--- a/src/sam/utils/spawn.js
+++ b/src/sam/utils/spawn.js
@@ -15,11 +15,7 @@ module.exports = function spawn (command, args, pretty, callback) {
   })
   pkg.on('close', (code) => {
     output = output.join('')
-    let noChanges = output.includes('No changes to deploy.')
-    if (code === 255 && noChanges) {
-      callback()
-    }
-    else if (code !== 0) {
+    if (code !== 0) {
       callback(Error(output))
     }
     else callback()


### PR DESCRIPTION
Removes redundant checks for 'No changes to deploy' in stdout/stderr.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!