### PR TITLE
use cfn deploy --debug when in arc verbose

### DIFF
--- a/src/sam/01-deploy/index.js
+++ b/src/sam/01-deploy/index.js
@@ -1,7 +1,7 @@
 let spawn = require('../utils/spawn')
 
 module.exports = function deploy (params, callback) {
-  let { stackname, bucket, pretty, region, update, tags } = params
+  let { stackname, bucket, pretty, region, update, tags, verbose } = params
   update.done('Generated CloudFormation deployment')
   update.start('Deploying & building infrastructure...')
   let template = 'sam.yaml'
@@ -16,6 +16,9 @@ module.exports = function deploy (params, callback) {
   if (tags.length > 0) {
     args.push('--tags')
     args = args.concat(tags)
+  }
+  if (verbose) {
+    args.push('--debug')
   }
   spawn('aws', args, pretty, callback)
 }


### PR DESCRIPTION
cdn deploy errors are much more useful with --debug turned on. and it is quite verbose. felt right to link it to `arc deploy --verbose`