### PR TITLE
Fix compatibility with REST API plugin

### DIFF
--- a/src/sam/compat/index.js
+++ b/src/sam/compat/index.js
@@ -13,7 +13,7 @@ module.exports = function compat (params, callback) {
     function getApiType (callback) {
       if (inv.http && (!inv.aws.apigateway || inv.aws.apigateway === 'rest')) {
         let deployPlugins = inv.plugins?._methods?.deploy?.start
-        let hasRestPlugin = deployPlugins?.find(({ plugin }) => plugin === 'architect/plugin-rest-api')
+        let hasRestPlugin = deployPlugins?.find(({ _plugin }) => _plugin === 'architect/plugin-rest-api')
 
         // Look for a legacy REST API in the stack; HTTP API resource IDs are simply 'HTTP'
         let resource = toLogicalID(inv.app)


### PR DESCRIPTION
I've been trying to get REST API functionality working in a project, and ran into the issue that after installing the REST API plugin and configuring my project to use it [as documented](https://github.com/architect/plugin-rest-api), I received the error message `Architect REST APIs are now supported via `@architect/plugin-rest-api`; please install that plugin and add `apigateway rest` to your @aws pragma`.

Some superficial digging led me to think the problem is simply a missing underscore. I added the underscore in my local copy and the project deployed without issue.

Notes:
- I attempted to run the tests, but got an eslint error. I didn't want to spend any more time digging further here, so I did not attempt to fix this. I have not run the test suite.