### PR TITLE
Handle CDN invalidations only if CDN explicitly enabled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Architect Deploy changelog
 
+## [5.0.8] 2024-06-06
+
+### Fixed
+
+- Handle CDN invalidations only if CDN explicitly enabled
+
 ---
 
 ## [5.0.8] 2025-01-23

--- a/src/sam/02-after/00-get-app-apex/index.js
+++ b/src/sam/02-after/00-get-app-apex/index.js
@@ -88,7 +88,7 @@ module.exports = function getAppApex (params, callback) {
           else callback()
         },
         function invalidateS3 (callback) {
-          if (s3 && !creatingS3 && !enablingS3 && !destroyingS3) {
+          if (cdnEnabled && s3 && !creatingS3 && !enablingS3 && !destroyingS3) {
             update.status('Invalidating static asset (S3) CDN distribution cache')
             aws.cloudfront.CreateInvalidation({
               Id: s3.id,
@@ -132,7 +132,7 @@ module.exports = function getAppApex (params, callback) {
           else callback()
         },
         function invalidateApiGateway (callback) {
-          if (apigateway && !creatingApiGateway && !enablingApiGateway && !destroyingApiGateway) {
+          if (cdnEnabled && apigateway && !creatingApiGateway && !enablingApiGateway && !destroyingApiGateway) {
             update.status('Invalidating API Gateway CDN distribution cache')
             aws.cloudfront.CreateInvalidation({
               Id: apigateway.id,


### PR DESCRIPTION
## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [x] Summarized your changes in `changelog.md`
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

## Changes
Hello, I've updated the CDN invalidation code to handle invalidation only if CDN explicitely enabled and managed by Architect.
This should unlock the discussion in https://github.com/architect/architect/issues/1483
